### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: super_logging
 description: The usual dart logging module, but with superpowers! Let's you easily log to stdout, disk and sentry.io.
-version: 1.0.0
+version: 1.0.1
 author: Dev Aggarwal <devpxy@gmail.com>
 homepage: https://github.com/scientifichackers/super_logging
 
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  package_info: ^0.4.0+13
+  package_info: '>=0.4.0+13 <2.0.0'
   device_info: ^0.4.1+4
   logging: ^0.11.4
   sentry: ^3.0.1


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).