### PR TITLE
Add a newline at the end of every LogRecord

### DIFF
--- a/lib/super_logging.dart
+++ b/lib/super_logging.dart
@@ -36,7 +36,7 @@ extension SuperLogRecord on LogRecord {
     for (var line in extraLines?.split('\n') ?? []) {
       msg += '\n$header $line';
     }
-    
+
     return msg;
   }
 

--- a/lib/super_logging.dart
+++ b/lib/super_logging.dart
@@ -37,6 +37,8 @@ extension SuperLogRecord on LogRecord {
       msg += '\n$header $line';
     }
 
+    msg += '\n';
+    
     return msg;
   }
 

--- a/lib/super_logging.dart
+++ b/lib/super_logging.dart
@@ -36,8 +36,6 @@ extension SuperLogRecord on LogRecord {
     for (var line in extraLines?.split('\n') ?? []) {
       msg += '\n$header $line';
     }
-
-    msg += '\n';
     
     return msg;
   }
@@ -209,7 +207,8 @@ class SuperLogging {
 
       // write to logfile
       if (fileIsEnabled) {
-        await logFile.writeAsString(str, mode: FileMode.append, flush: true);
+        final strForLogFile = str + '\n';
+        await logFile.writeAsString(strForLogFile, mode: FileMode.append, flush: true);
       }
 
       // add error to sentry queue


### PR DESCRIPTION
Currently the log-content piped to file is not very readable since there are no separators between two successive `LogRecord`s. This change inserts a newline at the end of each `LogRecord`.

Fixes: https://github.com/scientifichackers/super_logging/issues/6